### PR TITLE
Add RustDoc comments

### DIFF
--- a/src/extractors/amp_spectrum.rs
+++ b/src/extractors/amp_spectrum.rs
@@ -1,12 +1,6 @@
 extern crate num_complex;
 extern crate rustfft;
-/**
- * @brief      AMPLITUDE SPECTRUM
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     The amplitude spectrum vector (Vec::<f64>)
- */
+
 pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
     let fft_len = signal.len();
     let fft = rustfft::FFTplanner::new(false).plan_fft(fft_len);

--- a/src/extractors/bark_loudness.rs
+++ b/src/extractors/bark_loudness.rs
@@ -1,14 +1,6 @@
-use utils;
 use extractors::amp_spectrum;
+use utils;
 
-/**
- * @brief      SPECIFIC BARK LOUDNESS
- *
- * @param      signal  The signal vector (Vec::<f64>)
- * @param      sample_rate  The signal sample rate (f64)
- *
- * @return     Loudness in each Bark band (Vec::<f64>)
- */
 pub fn compute(signal: &Vec<f64>, sample_rate: f64) -> Vec<f64> {
     let mut amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 

--- a/src/extractors/energy.rs
+++ b/src/extractors/energy.rs
@@ -1,10 +1,3 @@
-/**
- * @brief      ENERGY
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the energy value (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let energy = signal
         .iter()
@@ -23,10 +16,12 @@ mod tests {
 
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let energy = compute(&dataset.signal);
-        assert_relative_eq!(energy,
-                            dataset.features.energy,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            energy,
+            dataset.features.energy,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/extractors/power_spectrum.rs
+++ b/src/extractors/power_spectrum.rs
@@ -1,11 +1,5 @@
 use extractors::amp_spectrum;
-/**
- * @brief      POWER SPECTRUM
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     The power spectrum vector (Vec::<f64>)
- */
+
 pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 

--- a/src/extractors/rms.rs
+++ b/src/extractors/rms.rs
@@ -1,10 +1,3 @@
-/**
- * @brief      ROOT MEAN SQUARE
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the RMS value (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let sum = signal
         .iter()
@@ -24,10 +17,12 @@ mod tests {
 
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let rms = compute(&dataset.signal);
-        assert_relative_eq!(rms,
-                            dataset.features.rms,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            rms,
+            dataset.features.rms,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/extractors/spectral_centroid.rs
+++ b/src/extractors/spectral_centroid.rs
@@ -1,13 +1,6 @@
-use utils;
 use extractors::amp_spectrum;
+use utils;
 
-/**
- * @brief      SPECTRAL CENTROID
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the spectral centroid value (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 
@@ -25,10 +18,12 @@ mod tests {
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let sc = compute(&dataset.signal);
 
-        assert_relative_eq!(sc,
-                            dataset.features.spectralCentroid,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            sc,
+            dataset.features.spectralCentroid,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]
@@ -40,4 +35,3 @@ mod tests {
         }
     }
 }
-

--- a/src/extractors/spectral_flatness.rs
+++ b/src/extractors/spectral_flatness.rs
@@ -1,12 +1,5 @@
 use extractors::amp_spectrum;
 
-/**
- * @brief      SPECTRAL FLATNESS
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the spectral flatness value (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 
@@ -28,10 +21,12 @@ mod tests {
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let sf = compute(&dataset.signal);
 
-        assert_relative_eq!(sf,
-                            dataset.features.spectralFlatness,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            sf,
+            dataset.features.spectralFlatness,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/extractors/spectral_kurtosis.rs
+++ b/src/extractors/spectral_kurtosis.rs
@@ -1,13 +1,6 @@
-use utils;
 use extractors::amp_spectrum;
+use utils;
 
-/**
- * @brief      SPECTRAL KURTOSIS
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the spectral kurtosis value (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 
@@ -16,8 +9,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
         .into_iter()
         .collect();
 
-    let numerator = -3.0 * mus[0].powf(4.0) + 6.0 * mus[0] * mus[1] - 4.0 * mus[0] * mus[2] +
-                    mus[3];
+    let numerator =
+        -3.0 * mus[0].powf(4.0) + 6.0 * mus[0] * mus[1] - 4.0 * mus[0] * mus[2] + mus[3];
 
     let denominator = (mus[1] - mus[0].powf(2.0)).sqrt().powf(4.0);
 
@@ -35,10 +28,12 @@ mod tests {
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let sk = compute(&dataset.signal);
 
-        assert_relative_eq!(sk,
-                            dataset.features.spectralKurtosis,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            sk,
+            dataset.features.spectralKurtosis,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/extractors/spectral_rolloff.rs
+++ b/src/extractors/spectral_rolloff.rs
@@ -1,12 +1,5 @@
 use extractors::amp_spectrum;
 
-/**
- * @brief      SPECTRAL ROLLOFF
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the spectral rolloff value (f64)
- */
 pub fn compute(signal: &Vec<f64>, sample_rate: f64, rolloff_point: Option<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
 
@@ -39,10 +32,12 @@ mod tests {
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let sr = compute(&dataset.signal, dataset.info.sampleRate as f64, None);
 
-        assert_relative_eq!(sr,
-                            dataset.features.spectralRolloff,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            sr,
+            dataset.features.spectralRolloff,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/extractors/zcr.rs
+++ b/src/extractors/zcr.rs
@@ -1,23 +1,16 @@
-/**
- * @brief      ZERO CROSSING RATE
- *
- * @param      signal  The signal vector (Vec::<f64>)
- *
- * @return     the zero crossing rate (f64)
- */
 pub fn compute(signal: &Vec<f64>) -> f64 {
     // here stats is a tuple, first element being the previous sample and next element being the ZCR accumulator
-    let zcr_tuple = signal
-        .iter()
-        .fold((0_f64, 0_f64), |stats, &sample| {
-            (sample,
-             stats.1 +
-             if stats.0.signum() != sample.signum() {
-                 1_f64
-             } else {
-                 0_f64
-             })
-        });
+    let zcr_tuple = signal.iter().fold((0_f64, 0_f64), |stats, &sample| {
+        (
+            sample,
+            stats.1
+                + if stats.0.signum() != sample.signum() {
+                    1_f64
+                } else {
+                    0_f64
+                },
+        )
+    });
 
     return zcr_tuple.1;
 }
@@ -32,10 +25,12 @@ mod tests {
 
     fn test_against(dataset: &test::data::TestDataSet) -> () {
         let zcr = compute(&dataset.signal);
-        assert_relative_eq!(zcr,
-                            dataset.features.zcr,
-                            epsilon = f64::EPSILON,
-                            max_relative = FLOAT_PRECISION);
+        assert_relative_eq!(
+            zcr,
+            dataset.features.zcr,
+            epsilon = f64::EPSILON,
+            max_relative = FLOAT_PRECISION
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! Meyda is a Rust library for audio feature extraction. It's based on [the
+//! original library in Javascript](https://meyda.js.org). It implements a
+//! variety of well known audio feature extraction algorithms.
+
 #[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
@@ -8,47 +12,167 @@ extern crate approx;
 mod extractors;
 mod utils;
 
+/// A type alias representing hertz
 pub type Hz = utils::Hz;
 
+///
+/// Root Mean Square
+///
+/// The root mean square of the waveform, that corresponds to its loudness.
+/// Corresponds to the `Energy` feature in YAAFE, adapted from Loy’s
+/// Musimathics.
+///
+/// RMS is used for information about the loudness of the sound.
+///
+/// G. Loy, Musimathics: The Mathematical Foundations of Music, Volume 1. The
+/// MIT Press, 2006.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
+///
+/// Returns the root mean square of the signal.
 pub fn get_rms(signal: &Vec<f64>) -> f64 {
     extractors::rms::compute(signal)
 }
 
+/// Energy
+///
+/// The infinite integral of the squared signal. According to Lathi.
+///
+/// B. P. Lathi, Modern Digital and Analog Communication Systems 3e Osece.
+/// Oxford University Press, 3rd ed., 1998.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_energy(signal: &Vec<f64>) -> f64 {
     extractors::energy::compute(signal)
 }
 
+/// Zero Crossing Rate
+///
+/// The number of times that the signal crosses the zero value in the buffer.
+///
+/// Used for differentiating between percussive and pitched sounds. Percussive
+/// sounds will have a random ZCR across buffers, whereas pitch sounds will
+/// return a more constant value.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_zcr(signal: &Vec<f64>) -> f64 {
     extractors::zcr::compute(signal)
 }
 
+/// Amplitude Spectrum
+///
+/// This is also known as the magnitude spectrum. By calculating the Fast
+/// Fourier Transform (FFT), we get the signal represented in the frequency
+/// domain. The output is an array, where each index is a frequency bin (i.e.
+/// containing information about a range of frequencies) containing a complex
+/// value (real and imaginary). The amplitude spectrum takes this complex array
+/// and computes the amplitude of each index. The result is the distribution of
+/// frequencies in the signal along with their corresponding strength. If you
+/// want to learn more about Fourier Transform, and the differences between
+/// time-domain to frequency-domain analysis, [this
+/// article](https://www.mathworks.com/help/signal/examples/practical-introduction-to-frequency-domain-analysis.html)
+/// is a good place to start.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_amp_spectrum(signal: &Vec<f64>) -> Vec<f64> {
     extractors::amp_spectrum::compute(signal)
 }
 
+/// Power Spectrum
+///
+/// This is the `amplitudeSpectrum` squared.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_power_spectrum(signal: &Vec<f64>) -> Vec<f64> {
     extractors::power_spectrum::compute(signal)
 }
 
+/// Spectral Centroid
+///
+/// An indicator of the "brightness" of a given sound, representing the spectral
+/// centre of gravity. If you were to take the spectrum, make a wooden block out
+/// of it and try to balance it on your finger (across the X axis), the spectral
+/// centroid would be the frequency that your finger "touches" when it
+/// successfully balances.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_spectral_centroid(signal: &Vec<f64>) -> f64 {
     extractors::spectral_centroid::compute(signal)
 }
 
+/// Spectral Flatness
+///
+/// The flatness of the spectrum. It is computed using the ratio between the
+/// geometric and arithmetic means.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_spectral_flatness(signal: &Vec<f64>) -> f64 {
     extractors::spectral_flatness::compute(signal)
 }
 
+/// Spectral Kurtosis
+///
+/// A measure of how quickly the spectrum of a signal is changing. It is
+/// calculated by computing the difference between the current spectrum and that
+/// of the previous frame.
+///
+/// ### Params:
+///
+/// - `signal`  The signal vector (`Vec<f64>`)
 pub fn get_spectral_kurtosis(signal: &Vec<f64>) -> f64 {
     extractors::spectral_kurtosis::compute(signal)
 }
 
-pub fn get_spectral_rolloff(signal: &Vec<f64>,
-                            sample_rate: f64,
-                            rolloff_point: Option<f64>)
-                            -> f64 {
+/// Spectral Rolloff
+///
+/// The frequency below which is contained a given % of the energy of the
+/// spectrum.
+///
+/// ### Params:
+///
+/// - `signal` The signal vector (`Vec<f64>`)
+/// - `sample_rate` The sample rate of the signal (Hz)
+/// - `rolloff_point` the given percentage (default: 0.99)
+pub fn get_spectral_rolloff(
+    signal: &Vec<f64>,
+    sample_rate: f64,
+    rolloff_point: Option<f64>,
+) -> f64 {
     extractors::spectral_rolloff::compute(signal, sample_rate, rolloff_point)
 }
 
+/// Specific Bark Loudness
+///
+/// Humans' perception of frequency is non-linear. The [Bark
+/// Scale](https://en.wikipedia.org/wiki/Bark_scale) was developed in order to
+/// have a scale on which equal distances correspond to equal distances of
+/// frequency perception.
+///
+/// Returns the loudness of the input sound on each step (often referred to as
+/// bands) of this scale (`.specific`). There are 24 bands overall.
+///
+/// Takes a signal vector `signal` (`Vec<f64>`) and the sample rate of the
+/// signal `sample_rate` (`f64`), and returns the Loudness in each Bark band
+/// `Vec<f64>`.
+///
+/// ### Params:
+///
+/// - `signal` The signal vector (`Vec<f64>`)
+/// - `sample_rate` The sample rate of the signal (Hz)
 pub fn get_bark_loudness(signal: &Vec<f64>, sample_rate: f64) -> Vec<f64> {
     extractors::bark_loudness::compute(signal, sample_rate)
 }


### PR DESCRIPTION
Converted existing doxygen style docs to rust, then pulled feature descriptons from [our public docs](https://meyda.js.org/audio-features) and amended where necessary.