### PR TITLE
Bump to rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "meyda"
 version = "0.1.0"
 authors = ["jakubfiala <mu201jf@gold.ac.uk>"]
+edition = "2021"
 
 [dependencies]
 rustfft = "6.0.1"
-num-complex = "0.4"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/extractors/amp_spectrum.rs
+++ b/src/extractors/amp_spectrum.rs
@@ -1,13 +1,12 @@
-extern crate num_complex;
-extern crate rustfft;
+use rustfft::{num_complex::Complex, FftPlanner};
 
 pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
     let fft_len = signal.len();
-    let fft = rustfft::FftPlanner::new().plan_fft_forward(fft_len);
+    let fft = FftPlanner::new().plan_fft_forward(fft_len);
 
     let mut fft_buffer: Vec<_> = signal
         .iter()
-        .map(|&sample| num_complex::Complex::new(sample, 0_f64))
+        .map(|&sample| Complex::new(sample, 0_f64))
         .collect();
 
     fft.process(&mut fft_buffer);
@@ -27,8 +26,8 @@ pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.333_333;
 

--- a/src/extractors/bark_loudness.rs
+++ b/src/extractors/bark_loudness.rs
@@ -1,5 +1,5 @@
-use extractors::amp_spectrum;
-use utils;
+use crate::extractors::amp_spectrum;
+use crate::utils;
 
 pub fn compute(signal: &Vec<f64>, sample_rate: f64) -> Vec<f64> {
     let mut amp_spec: Vec<f64> = amp_spectrum::compute(signal);

--- a/src/extractors/energy.rs
+++ b/src/extractors/energy.rs
@@ -9,8 +9,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_000_010;
 

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,8 +1,8 @@
+pub mod energy;
 /**
  * Extractors index
  */
 pub mod rms;
-pub mod energy;
 pub mod zcr;
 
 pub mod amp_spectrum;

--- a/src/extractors/power_spectrum.rs
+++ b/src/extractors/power_spectrum.rs
@@ -1,4 +1,4 @@
-use extractors::amp_spectrum;
+use crate::extractors::amp_spectrum;
 
 pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
@@ -11,8 +11,8 @@ pub fn compute(signal: &Vec<f64>) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.333_333;
 

--- a/src/extractors/rms.rs
+++ b/src/extractors/rms.rs
@@ -10,8 +10,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_000_010;
 

--- a/src/extractors/spectral_centroid.rs
+++ b/src/extractors/spectral_centroid.rs
@@ -1,5 +1,5 @@
-use extractors::amp_spectrum;
-use utils;
+use crate::extractors::amp_spectrum;
+use crate::utils;
 
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
@@ -10,8 +10,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_001_000;
 

--- a/src/extractors/spectral_flatness.rs
+++ b/src/extractors/spectral_flatness.rs
@@ -1,4 +1,4 @@
-use extractors::amp_spectrum;
+use crate::extractors::amp_spectrum;
 
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
@@ -13,8 +13,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.001_000_000;
 

--- a/src/extractors/spectral_kurtosis.rs
+++ b/src/extractors/spectral_kurtosis.rs
@@ -1,5 +1,5 @@
-use extractors::amp_spectrum;
-use utils;
+use crate::extractors::amp_spectrum;
+use crate::utils;
 
 pub fn compute(signal: &Vec<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
@@ -20,8 +20,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_010_000;
 

--- a/src/extractors/spectral_rolloff.rs
+++ b/src/extractors/spectral_rolloff.rs
@@ -1,4 +1,4 @@
-use extractors::amp_spectrum;
+use crate::extractors::amp_spectrum;
 
 pub fn compute(signal: &Vec<f64>, sample_rate: f64, rolloff_point: Option<f64>) -> f64 {
     let amp_spec: Vec<f64> = amp_spectrum::compute(signal);
@@ -24,8 +24,8 @@ pub fn compute(signal: &Vec<f64>, sample_rate: f64, rolloff_point: Option<f64>) 
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_000_010;
 

--- a/src/extractors/zcr.rs
+++ b/src/extractors/zcr.rs
@@ -18,8 +18,8 @@ pub fn compute(signal: &Vec<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::compute;
+    use crate::utils::test;
     use std::f64;
-    use utils::test;
 
     const FLOAT_PRECISION: f64 = 0.000_000_010;
 

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -3,11 +3,10 @@ pub mod data {
     extern crate serde;
     extern crate serde_json;
 
-    use std::error::Error;
+    use std::f64;
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
-    use std::f64;
 
     #[allow(non_snake_case)]
     #[derive(Serialize, Deserialize)]
@@ -51,19 +50,19 @@ pub mod data {
         let display = path.display();
 
         let mut file = match File::open(&path) {
-            Err(why) => panic!("couldn't open {}: {}", display, why.description()),
+            Err(why) => panic!("couldn't open {}: {}", display, why),
             Ok(file) => file,
         };
 
         let mut json_str = String::new();
         match file.read_to_string(&mut json_str) {
-            Err(why) => panic!("couldn't read {}: {}", display, why.description()),
+            Err(why) => panic!("couldn't read {}: {}", display, why),
             Ok(_) => (),
         }
 
         let data: TestDataSet = match serde_json::from_str(&json_str) {
             Ok(d) => d,
-            Err(err) => panic!("{:?}", err.description()),
+            Err(err) => panic!("{:?}", err),
         };
 
         data
@@ -77,7 +76,8 @@ pub mod data {
 
     pub fn approx_compare_vec(vec1: &Vec<f64>, vec2: &Vec<f64>, precision: f64) -> () {
         #[allow(unused_variables)]
-        let zipped: Vec<_> = vec1.iter()
+        let zipped: Vec<_> = vec1
+            .iter()
             .zip(vec2.iter())
             .inspect(|x| {
                 assert_relative_eq!(x.0, x.1, max_relative = precision, epsilon = f64::EPSILON)


### PR DESCRIPTION
- Bump to rust edition 2021
- Fix relevant internal crate use statements which now require `crate::` prefix
- Remove direct dependency on num_complex, instead rely on the one re-exported from rustfft so that we remain in sync
- Remove calls to deprecated `.description()` on error instances, those implement `Display` now.